### PR TITLE
SN-171 & SN-107: Fix bug for storing accesa and video + store images from object detection to S3

### DIFF
--- a/WebService/Services/s3_service.py
+++ b/WebService/Services/s3_service.py
@@ -21,6 +21,14 @@ class S3Service:
             return False
         return True
 
+    def put_file(self, bucket, file_string, key):
+        try:
+            response = self.s3.put_object(Bucket=bucket, Key=key, Body=bytes(file_string))
+        except ClientError as e:
+            logging.error(e)
+            return False
+        return True
+
     def generate_url(self, bucket, key, expiration=360):
         try:
             response = self.s3.generate_presigned_url('get_object', Params={'Bucket': bucket, 'Key': key},

--- a/WebService/camera.py
+++ b/WebService/camera.py
@@ -11,8 +11,8 @@ from notification_service import NotificationService
 
 class Video(object):
     def __init__(self, queueSize=128, cameraSource=0, timeout=0):
-        self.video = CamVideoStream(0)
-        time.sleep(10)
+        self.video = CamVideoStream(1)
+        time.sleep(1)
         self.video.start()
         # network to coco weight file and cfg file
         self.net_coco = cv2.dnn.readNetFromDarknet('cfg_files/yolov4.cfg', 'weight_files/yolov4.weights')
@@ -22,8 +22,7 @@ class Video(object):
                                                         'weight_files/yolov4-custom_bird_mail_new.weights')
 
         # network to the user pets custom yolov4 wight file and cfg file
-       # self.net_user_pet = cv2.dnn.readNetFromDarknet('cfg_files/yolov4-custom_user_pets.cfg',
-        #                                               'weight_files/yolov4-custom_user_pets.weights')
+        self.net_user_pet = cv2.dnn.readNetFromDarknet('cfg_files/yolov4-custom_user_pets.cfg', 'weight_files/yolov4-custom_user_pets.weights')
         self.keyClipSerivce = KeyClipService(bufSize=32)
         self.consecFrames = 0
         self.pet_detection = petDetection()
@@ -46,7 +45,7 @@ class Video(object):
         mail_bird_classes = self.pet_detection.getClasses('names_files/mail-bird.names')
 
         # reading the user_pets.names file.
-       # user_pets_classes = self.pet_detection.getClasses('names_files/user_pets.names')
+        user_pets_classes = self.pet_detection.getClasses('names_files/user_pets.names')
         # get the height and width
         height, width, _ = frame.shape
         blob = cv2.dnn.blobFromImage(frame, 1 / 255, (416, 416), (0, 0, 0), swapRB=True, crop=False)
@@ -54,14 +53,13 @@ class Video(object):
         # self.net.setInput(blob)
         self.net_coco.setInput(blob)
         self.net_mail_bird.setInput(blob)
-   #     self.net_user_pet.setInput(blob)
+        self.net_user_pet.setInput(blob)
 
         # Getting the bonding boxes, confidence for each box, and class ids
         boxes_coco, confidences_coco, class_ids_coco = self.pet_detection.getNumbers(self.net_coco, width, height)
         boxes_mail_bird, confidences_mail_bird, class_ids_mail_bird = self.pet_detection.getNumbers(self.net_mail_bird,
                                                                                                     width, height)
-      #  boxes_user_pets, confidences_user_pets, class_ids_user_pets = self.pet_detection.getNumbers(self.net_user_pet,
-       #                                                                                             width, height)
+        boxes_user_pets, confidences_user_pets, class_ids_user_pets = self.pet_detection.getNumbers(self.net_user_pet, width, height)
 
         # indexes_coco will be empty if there is no objects are detected in the image
         indexes_coco = cv2.dnn.NMSBoxes(boxes_coco, confidences_coco, .5, .4)
@@ -169,13 +167,15 @@ class Video(object):
                 timestamp = datetime.datetime.now()
                 p = "{}/{}.mp4".format('tmp', timestamp.strftime("%Y%m%d-%H%M%S"))
                 f = "{}.mp4".format(timestamp.strftime("%Y%m%d-%H%M%S"))
-              #  self.keyClipSerivce.start(p, f, labels, cv2.VideoWriter_fourcc('M', 'P', '4', 'V'), 20, width, height,
-               #                           user_pets_classes)
+                self.keyClipSerivce.start(p, f, labels, cv2.VideoWriter_fourcc('M', 'P', '4', 'V'), 20, width, height, user_pets_classes)
 
         if updateConsecFrames:
             self.consecFrames += 1
         self.keyClipSerivce.update(frame)
-        if self.keyClipSerivce.recording and self.consecFrames == 32:
+        print(self.consecFrames)
+        print(self.keyClipSerivce.recording)
+        if self.keyClipSerivce.recording and self.consecFrames == 16:
+            print("calling finish")
             self.keyClipSerivce.finish()
 
         ret, jpg = cv2.imencode('.jpg', frame)

--- a/WebService/camera.py
+++ b/WebService/camera.py
@@ -12,7 +12,7 @@ from notification_service import NotificationService
 class Video(object):
     def __init__(self, queueSize=128, cameraSource=0, timeout=0):
         self.video = CamVideoStream(0)
-        time.sleep(10)
+        time.sleep(9)
         self.video.start()
         # network to coco weight file and cfg file
         self.net_coco = cv2.dnn.readNetFromDarknet('cfg_files/yolov4.cfg', 'weight_files/yolov4.weights')

--- a/WebService/camera.py
+++ b/WebService/camera.py
@@ -11,8 +11,8 @@ from notification_service import NotificationService
 
 class Video(object):
     def __init__(self, queueSize=128, cameraSource=0, timeout=0):
-        self.video = CamVideoStream(1)
-        time.sleep(1)
+        self.video = CamVideoStream(0)
+        time.sleep(10)
         self.video.start()
         # network to coco weight file and cfg file
         self.net_coco = cv2.dnn.readNetFromDarknet('cfg_files/yolov4.cfg', 'weight_files/yolov4.weights')

--- a/WebService/camera.py
+++ b/WebService/camera.py
@@ -172,7 +172,10 @@ class Video(object):
         if updateConsecFrames:
             self.consecFrames += 1
         self.keyClipSerivce.update(frame)
-        if self.keyClipSerivce.recording and self.consecFrames == 16:
+        print(self.consecFrames)
+        print(self.keyClipSerivce.recording)
+        if self.keyClipSerivce.recording and self.consecFrames == 6:
+            print("calling finish")
             self.keyClipSerivce.finish()
 
         ret, jpg = cv2.imencode('.jpg', frame)

--- a/WebService/camera.py
+++ b/WebService/camera.py
@@ -172,10 +172,7 @@ class Video(object):
         if updateConsecFrames:
             self.consecFrames += 1
         self.keyClipSerivce.update(frame)
-        print(self.consecFrames)
-        print(self.keyClipSerivce.recording)
         if self.keyClipSerivce.recording and self.consecFrames == 6:
-            print("calling finish")
             self.keyClipSerivce.finish()
 
         ret, jpg = cv2.imencode('.jpg', frame)

--- a/WebService/camera.py
+++ b/WebService/camera.py
@@ -172,10 +172,7 @@ class Video(object):
         if updateConsecFrames:
             self.consecFrames += 1
         self.keyClipSerivce.update(frame)
-        print(self.consecFrames)
-        print(self.keyClipSerivce.recording)
         if self.keyClipSerivce.recording and self.consecFrames == 16:
-            print("calling finish")
             self.keyClipSerivce.finish()
 
         ret, jpg = cv2.imencode('.jpg', frame)

--- a/WebService/key_clip_service.py
+++ b/WebService/key_clip_service.py
@@ -9,6 +9,7 @@ from notification_service import NotificationService
 import mysql.connector
 import time
 import cv2
+import datetime
 
 DATABASE_CONNECTION_INFO = 'mysql://admin:abir1971@pet-project.cqlvbpbplnsv.us-east-2.rds.amazonaws.com/automated_pet_door'
 
@@ -80,6 +81,7 @@ class KeyClipService:
         self.flush()
         self.writer.release()
         self.save_key_event_clip()
+        self.save_image_frame()
         self.outputPath = None
         self.outputFile = None
         self.labels = None
@@ -100,3 +102,14 @@ class KeyClipService:
             db_session = self.DBSession
             db_session.add(new_event)
             db_session.commit()
+
+    def save_image_frame(self):
+        if self.frames is not None:
+            if self.frames[0] is not None:
+                image = self.frames[len(self.frames) - 1]
+                timestamp = datetime.datetime.now()
+                p = "{}/{}.jpg".format('tmp', timestamp.strftime("%Y%m%d-%H%M%S"))
+                f = "{}.jpg".format(timestamp.strftime("%Y%m%d-%H%M%S"))
+                cv2.imwrite(p, image)
+                result = self.s3_service.upload_file('image-snapshots', p, f)
+


### PR DESCRIPTION
This pull request closes bug request #SN-171 and story #SN-107

**SN-171**

The bug was due to some code changes that made it so the keyClipWriter.start was never execute. This has been fixed as shown in this video:

https://drive.google.com/file/d/1S-26nDAEPsYVc3eyPEa_wh9tQI7VXKYw/view?usp=sharing

**SN-107**

Whenever an object is detected, a jpeg image will be stored in our S3 bucket called images-snapshots. When we train the model next, we can download all of the images on there and add them to our dataset to improve the model. This functionality is shown in this video:

https://drive.google.com/file/d/1ADXBEPHkYheGHx1IqFxc9CNSDCcDs-lG/view?usp=sharing






